### PR TITLE
Add blaes.ing

### DIFF
--- a/names/blaes.ing.yml
+++ b/names/blaes.ing.yml
@@ -1,0 +1,5 @@
+domain: blaes.ing
+name: Frederick Bläsing
+title: High school student & hobbyist programmer
+url: https://frederick.blaes.ing/
+github: fr-bl

--- a/names/blaes.ing.yml
+++ b/names/blaes.ing.yml
@@ -1,5 +1,5 @@
 domain: blaes.ing
-name: Frederick Bläsing
+name: Frederick Blaesing
 title: High school student & hobbyist programmer
 url: https://frederick.blaes.ing/
 github: fr-bl


### PR DESCRIPTION
I actually use the https://frederick.blaes.ing subdomain, but wasn't sure if 3rd level domains can be used in the filename and domain entry. It's only present in the URL entry for now.